### PR TITLE
Refactor: Implementar UI de pantalla completa con barras laterales

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1,19 +1,17 @@
 /* Reset & Base styles */
 * { box-sizing: border-box; margin: 0; padding: 0; }
 html, body {
-    /* Estas propiedades ya no son necesarias aquí */
+    width: 100%;
+    height: 100%;
     margin: 0;
     padding: 0;
+    overflow: hidden; /* Evita el scroll en la página principal */
 }
 
 body {
     font-family: 'Roboto', system-ui, -apple-system, sans-serif;
     background: #141414;
     color: #fff;
-    min-height: 100vh;
-    padding: 10px; /* Simplified padding for mobile */
-    /* Añadimos espacio abajo para la barra de navegación fija */
-    padding-bottom: 120px;
 }
 
 /* Header */
@@ -37,23 +35,107 @@ h1 {
 /* Layout */
 main {
     width: 100%;
-    margin: 20px auto 0;
-    /* La propiedad padding-bottom se ha movido al body */
+    height: 100%;
+    margin: 0;
+    padding: 0;
 }
 
 footer {
+    display: none; /* Ocultamos el footer que ya no es necesario */
+}
+
+#section-alineacio {
     width: 100%;
-    margin: 20px auto 80px; /* Adjust margin for mobile */
-    padding: 0 10px;
+    height: 100%;
 }
 
 /* Campo y Overlay */
 .campo-container {
-    width: 90vw;
-    max-width: 450px; /* Max width for larger screens */
-    aspect-ratio: 5 / 8;
+    width: 100%;
+    height: 100%;
+    max-width: 100%;
     position: relative;
     margin: 0 auto;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+}
+
+/* Estilos para los nuevos botones de las barras laterales */
+.sidebar-toggle-btn {
+    position: fixed;
+    top: 15px;
+    z-index: 1001; /* Encima de todo excepto los modales */
+    background-color: rgba(0, 170, 255, 0.9);
+    color: white;
+    border: none;
+    border-radius: 50%;
+    width: 50px;
+    height: 50px;
+    font-size: 1.2rem;
+    cursor: pointer;
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
+    transition: transform 0.2s ease, background-color 0.2s ease;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+}
+
+.sidebar-toggle-btn:hover {
+    transform: scale(1.1);
+    background-color: #00aaff;
+}
+
+.sidebar-toggle-btn.left {
+    left: 15px;
+}
+
+.sidebar-toggle-btn.right {
+    right: 15px;
+}
+
+/* Estilos para las barras laterales */
+.sidebar {
+    position: fixed;
+    top: 0;
+    height: 100%;
+    width: 280px;
+    max-width: 80vw;
+    background: #1c2127;
+    z-index: 1000;
+    box-shadow: 0 0 20px rgba(0, 0, 0, 0.5);
+    transition: transform 0.3s ease-in-out;
+    display: flex;
+    flex-direction: column;
+    padding: 20px;
+    padding-top: 60px; /* Espacio para que no se solape con el botón de cerrar */
+}
+
+.sidebar.left {
+    left: 0;
+    transform: translateX(-100%);
+}
+
+.sidebar.right {
+    right: 0;
+    transform: translateX(100%);
+}
+
+.sidebar.visible {
+    transform: translateX(0);
+}
+
+.sidebar h2 {
+    color: #00aaff;
+    margin-bottom: 20px;
+    text-align: center;
+}
+
+/* Permitir scroll interno en la lista de jugadores */
+.sidebar .carrusel {
+    overflow-y: auto;
+    flex-grow: 1; /* Ocupa el espacio restante */
+    padding-right: 10px; /* Espacio para la barra de scroll */
 }
 
 .campo {
@@ -796,7 +878,9 @@ input, select, textarea {
     display: flex;
     flex-direction: column;
     gap: 20px;
-    margin-top: 20px;
+    width: 100%;
+    height: 100%;
+    overflow-y: auto; /* Permite scroll si el contenido es largo */
 }
 
 #creacion-jugada-panel,

--- a/index.html
+++ b/index.html
@@ -13,9 +13,40 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/pako/2.1.0/pako.min.js"></script>
 </head>
 <body>
-    <header>
-        <h1>ALINSTATS</h1>
-        <p class="subtitulo">Alineació automàtica i estadístiques</p>    </header>
+    <!-- Botón para abrir la barra lateral de jugadores -->
+    <button id="btn-toggle-equip" class="sidebar-toggle-btn left">
+        <i class="fas fa-users"></i>
+    </button>
+
+    <!-- Barra lateral de Jugadores (Modo Equip) -->
+    <div id="sidebar-equip" class="sidebar left">
+        <h2>Jugadors Disponibles</h2>
+        <div class="carrusel" id="carrusel-convocatoria"></div>
+    </div>
+
+    <!-- Botón para abrir la barra lateral de opciones de la pizarra -->
+    <button id="btn-toggle-pissarra" class="sidebar-toggle-btn right" style="display: none;">
+        <i class="fas fa-cog"></i>
+    </button>
+
+    <!-- Barra lateral de Opciones (Modo Pissarra) -->
+    <div id="sidebar-pissarra" class="sidebar right">
+        <div id="pizarra-controls-container">
+            <div id="creacion-jugada-panel">
+                <h3>Creación de Jugada</h3>
+                <div class="pizarra-buttons">
+                    <button id="reiniciar-posiciones-btn" class="nav-btn"><i class="fas fa-undo"></i>Reiniciar</button>
+                    <button id="iniciar-grabacion-btn" class="nav-btn"><i class="fas fa-play-circle"></i>Grabar</button>
+                    <button id="anadir-paso-btn" class="nav-btn" disabled><i class="fas fa-plus"></i>Añadir Paso</button>
+                    <button id="finalizar-jugada-btn" class="nav-btn" disabled><i class="fas fa-save"></i>Finalizar</button>
+                </div>
+            </div>
+            <div id="jugadas-guardadas-panel">
+                <h3>Jugadas Guardadas</h3>
+            </div>
+        </div>
+    </div>
+
     <main>
         <section id="section-alineacio">
             <div class="campo-container">
@@ -41,20 +72,6 @@
                         <path d="M 220 790 L 220 800 L 280 800 L 280 790" fill="none" stroke="#fff" stroke-width="4"/>
                     </svg>
                     <div class="overlay" id="overlay-fichas"></div>
-                </div>
-            </div>
-            <div id="pizarra-controls-container" style="display: none;">
-                <div id="creacion-jugada-panel">
-                    <h3>Creación de Jugada</h3>
-                    <div class="pizarra-buttons">
-                        <button id="reiniciar-posiciones-btn" class="nav-btn"><i class="fas fa-undo"></i>Reiniciar</button>
-                        <button id="iniciar-grabacion-btn" class="nav-btn"><i class="fas fa-play-circle"></i>Grabar</button>
-                        <button id="anadir-paso-btn" class="nav-btn" disabled><i class="fas fa-plus"></i>Añadir Paso</button>
-                        <button id="finalizar-jugada-btn" class="nav-btn" disabled><i class="fas fa-save"></i>Finalizar</button>
-                    </div>
-                </div>
-                <div id="jugadas-guardadas-panel">
-                    <h3>Jugadas Guardadas</h3>
                 </div>
             </div>
         </section>
@@ -120,25 +137,6 @@
             <div id="clips-lista" class="clips-grid"></div>
         </section>
     </main>
-    <div class="carrusel-container">
-        <h2>JUGADORS DISPONIBLES</h2>
-        <div class="carrusel" id="carrusel-convocatoria"></div>
-    </div>
-    <div class="button-container">
-        <button id="btn-alineacio" class="nav-btn">
-            <i class="fas fa-users"></i>
-            Equip
-        </button>
-        <button id="btn-estadistiques" class="nav-btn">
-            <i class="fas fa-chart-bar"></i>
-            Stats
-        </button>
-        <button id="btn-clips" class="nav-btn">
-            <i class="fas fa-film"></i>
-            Clips
-        </button>
-    </div>    <footer>
-    </footer>
     <div id="modal-backdrop" class="modal-backdrop"></div>
     <div id="modal-popup" class="modal-popup">
         <div id="modal-content"></div>

--- a/js/main.js
+++ b/js/main.js
@@ -109,9 +109,26 @@ document.addEventListener('DOMContentLoaded', () => {
     }
 
     // Navigation Event Listeners
-    elements.nav.btnEstadistiques.addEventListener('click', () => activarTab('estadistiques'));
-    elements.nav.btnAlineacio.addEventListener('click', () => activarTab('alineacio'));
-    elements.nav.btnClips.addEventListener('click', () => activarTab('clips'));
+    if (elements.nav.btnToggleEquip) {
+        elements.nav.btnToggleEquip.addEventListener('click', (e) => {
+            e.stopPropagation(); // Evita que el clic se propague al main
+            elements.sidebars.equip.classList.toggle('visible');
+        });
+    }
+
+    // Listener para cerrar la sidebar si se clica fuera
+    document.querySelector('main').addEventListener('click', () => {
+        elements.sidebars.equip.classList.remove('visible');
+        elements.sidebars.pissarra.classList.remove('visible');
+    });
+
+    if (elements.nav.btnTogglePissarra) {
+        elements.nav.btnTogglePissarra.addEventListener('click', (e) => {
+            e.stopPropagation();
+            elements.sidebars.pissarra.classList.toggle('visible');
+        });
+    }
+
     elements.modal.backdrop.addEventListener('click', cerrarModal);
 
     if (elements.togglePizarraBtn) {

--- a/js/state.js
+++ b/js/state.js
@@ -49,7 +49,19 @@ const state = {
         nav: {
             btnEstadistiques: null,
             btnAlineacio: null,
-            btnClips: null
+            btnClips: null,
+            btnToggleEquip: null
+        },
+        sidebars: {
+            equip: null,
+            pissarra: null
+        },
+        nav: {
+            btnEstadistiques: null,
+            btnAlineacio: null,
+            btnClips: null,
+            btnToggleEquip: null,
+            btnTogglePissarra: null
         },
         pizarra: {
             controlsContainer: null,
@@ -181,9 +193,10 @@ export function initElements() {
     state.elements.clips.selector = document.getElementById('partit-selector-clips');
     state.elements.clips.lista = document.getElementById('clips-lista');
     state.elements.clips.addBtn = document.getElementById('add-clip-btn-main');
-    state.elements.nav.btnEstadistiques = document.getElementById('btn-estadistiques');
-    state.elements.nav.btnAlineacio = document.getElementById('btn-alineacio');
-    state.elements.nav.btnClips = document.getElementById('btn-clips');
+    state.elements.nav.btnToggleEquip = document.getElementById('btn-toggle-equip');
+    state.elements.nav.btnTogglePissarra = document.getElementById('btn-toggle-pissarra');
+    state.elements.sidebars.equip = document.getElementById('sidebar-equip');
+    state.elements.sidebars.pissarra = document.getElementById('sidebar-pissarra');
     state.elements.pizarra.controlsContainer = document.getElementById('pizarra-controls-container');
     state.elements.pizarra.creacionJugadaPanel = document.getElementById('creacion-jugada-panel');
     state.elements.pizarra.jugadasGuardadasPanel = document.getElementById('jugadas-guardadas-panel');

--- a/js/ui.js
+++ b/js/ui.js
@@ -1011,21 +1011,18 @@ export function togglePizarraTactical() {
     elements.campo.classList.toggle('pizarra-activa', state.isPizarraTacticalMode);
     elements.togglePizarraBtn.textContent = state.isPizarraTacticalMode ? 'Modo Pizarra: ON' : 'Pizarra Táctica';
 
-    const carruselContainer = document.querySelector('.carrusel-container');
-    if (carruselContainer) {
-        carruselContainer.style.display = state.isPizarraTacticalMode ? 'none' : 'block';
-    }
-
-    const pizarraControls = document.getElementById('pizarra-controls-container');
-    if (pizarraControls) {
-        pizarraControls.style.display = state.isPizarraTacticalMode ? 'block' : 'none';
-    }
+    // Controla la visibilidad de los botones de las barras laterales
+    elements.nav.btnToggleEquip.style.display = state.isPizarraTacticalMode ? 'none' : 'flex';
+    elements.nav.btnTogglePissarra.style.display = state.isPizarraTacticalMode ? 'flex' : 'none';
 
     if (state.isPizarraTacticalMode) {
         renderizarPizarra();
         setupPizarraEventListeners();
         renderizarJugadasGuardadas();
     } else {
+        // Si salimos del modo pizarra, cerramos las sidebars
+        elements.sidebars.equip.classList.remove('visible');
+        elements.sidebars.pissarra.classList.remove('visible');
         elements.overlay.style.pointerEvents = 'none';
         renderizarAlineacion(state.alineacionActual, false);
         elements.campo.classList.remove('recording');


### PR DESCRIPTION
He refactorizado completamente la interfaz de usuario para adoptar un patrón de vista completa (100vh), eliminando el scroll de la página principal para resolver conflictos de gestos en dispositivos móviles.

- El campo de juego ahora ocupa el 100% de la altura de la pantalla.
- Los controles de selección de jugadores se han movido a una barra lateral izquierda desplegable ('Modo Equip').
- Los controles de la pizarra táctica se han movido a una barra lateral derecha desplegable, visible solo en 'Modo Pissarra'.
- He añadido botones flotantes para controlar la visibilidad de las nuevas barras laterales.
- He eliminado el HTML y CSS de la antigua interfaz (header, carrusel de jugadores inferior y barra de navegación).